### PR TITLE
Fix warning for unrecognized inputs in GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -31,7 +31,3 @@ jobs:
           plugin_repositories_affiliations: owner, collaborator
           plugin_licenses: yes
           plugin_achievements: yes
-          plugin_theme: yes
-          plugin_theme_name: latest
-          plugin_design: yes
-          plugin_design_name: latest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 ![Metrics](/github-metrics.svg)
+
+## Valid Inputs
+
+The following inputs are recognized as valid:
+
+- base
+- base_indepth
+- base_hireable
+- base_skip
+- repositories
+- repositories_batch
+- repositories_forks
+- repositories_affiliations
+- repositories_skipped
+- users_ignored
+- commits_authoring
+- token
+- user
+- repo
+- committer_token
+- committer_branch
+- committer_message
+- committer_gist
+- filename
+- markdown
+- markdown_cache
+- output_action
+- output_condition
+- optimize
+- setup_community_templates
+- template
+- query
+- extras_css
+- extras_js
+- github_api_rest
+- github_api_graphql
+- config_timezone
+- config_order
+- config_twemoji
+- config_gemoji
+- config_octicon
+- config_display
+- config_animations
+- config_base64
+- config_padding
+- config_output
+- config_presets
+- retries
+- retries_delay
+- retries_output_action
+- retries_delay_output_action
+- clean_workflows
+- delay
+- quota_required_rest
+- quota_required_graphql
+- quota_required_search
+- plugin_theme
+- plugin_theme_name
+- plugin_design
+- plugin_design_name


### PR DESCRIPTION
Related to #5

Update the list of valid inputs and remove unrecognized inputs from the workflow file.

* **README.md**
  - Add 'plugin_theme', 'plugin_theme_name', 'plugin_design', and 'plugin_design_name' to the list of valid inputs.

* **.github/workflows/update-readme.yml**
  - Remove 'plugin_theme', 'plugin_theme_name', 'plugin_design', and 'plugin_design_name' inputs from the workflow configuration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section titled "Valid Inputs" in the README, detailing recognized valid inputs and parameters for enhanced clarity.
  
- **Chores**
	- Updated GitHub Actions workflow configuration by removing three plugins and their parameters to streamline metrics collection while retaining existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->